### PR TITLE
point at correct static files dir

### DIFF
--- a/files/conf/nginx.conf
+++ b/files/conf/nginx.conf
@@ -94,7 +94,7 @@ ssl_ciphers "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECD
 
     location /static {
         autoindex on;
-        alias {{project_root}}/code/static/;
+        alias {{project_root}}/code/ynr/static/;
     }
 
     location /media {


### PR DESCRIPTION
I haven't tested this on a staging deploy, but I've had a dig about on the server and by the looks of it, the files in `{{project_root}}/code/static/` are stale artefacts from a previous deploy (before everything got moved about). The files in `{{project_root}}/code/ynr/static/` seem to be from the most recent `collectstatic`. I suspect this will fix 

https://github.com/DemocracyClub/yournextrepresentative/issues/425 and
https://github.com/DemocracyClub/yournextrepresentative/issues/427 and possibly some other things.

Do test it on staging though.