### PR TITLE
Stop uploaded candidate images from being ovewritten

### DIFF
--- a/webapp_settings/production.py
+++ b/webapp_settings/production.py
@@ -113,6 +113,7 @@ DEFAULT_FILE_STORAGE= 'ynr.s3_storage.MediaStorage'
 AWS_S3_REGION_NAME = 'eu-west-2'
 AWS_STORAGE_BUCKET_NAME = "static-candidates.democracyclub.org.uk"
 AWS_S3_CUSTOM_DOMAIN = "static-candidates.democracyclub.org.uk"
+AWS_S3_FILE_OVERWRITE = False
 STATICFILES_LOCATION = 'static'
 MEDIAFILES_LOCATION = 'media'
 


### PR DESCRIPTION
Unlike the default `django.core.files.storage.FileSystemStorage` storage, `storages.backends.s3boto3.S3Boto3Storage` will overwrite files with the same name rather than generating a new filename. The YNR code assumed that a new filename would be generated in this case, so when the storage was switched to `S3Boto3Storage` images are being overwritten rather than being stored alongside. From the documentation and code it looks as if setting `AWS_S3_FILE_OVERWRITE = False` should fix this.

Fixes https://github.com/DemocracyClub/yournextrepresentative/issues/1096